### PR TITLE
Magic folder and Abstract common functions to base class

### DIFF
--- a/src/Domain.php
+++ b/src/Domain.php
@@ -2,7 +2,7 @@
 
 namespace Coreproc\Enom;
 
-class Domain
+class Domain extends Service
 {
 
     /**
@@ -190,21 +190,4 @@ class Domain
         return $response;
     }
 
-    private function doGetRequest($command, $additionalParams = [])
-    {
-        $params = [
-            'command' => $command,
-        ];
-
-        if (count($additionalParams)) {
-            $params = array_merge($params, $additionalParams);
-        }
-
-        return $this->client->get('', ['query' => $params])->xml();
-    }
-
-    private function parseXMLObject($object)
-    {
-        return json_decode(json_encode($object));
-    }
 }

--- a/src/MagicFolder.php
+++ b/src/MagicFolder.php
@@ -2,7 +2,7 @@
 
 namespace Coreproc\Enom;
 
-class MagicFolder
+class MagicFolder extends Service
 {
 
     /**

--- a/src/MagicFolder.php
+++ b/src/MagicFolder.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Coreproc\Enom;
+
+class MagicFolder
+{
+
+    /**
+     * @var Enom
+     */
+    private $enom;
+
+    private $client;
+
+    public function __construct(Enom $enom)
+    {
+        $this->enom = $enom;
+        $this->client = $enom->getClient();
+    }
+
+	/**
+	* Assign one or more domains to one folder.
+	* @var $domainNameList mixed - Array or string
+	*/
+    public function assignToDomainFolder($domainNameList, $toFolderName, 
+    	$transferMode=1, $fromFolderName)
+    {
+        $response = $this->doGetRequest('AssignToDomainFolder', [
+            'domainnamelist' => is_array($domainNameList) ? implode(',', $domainNameList) : $domainNameList,
+            'transfermode' => $transferMode,
+            'fromfoldername' => $fromFolderName,
+            'tofoldername' => $toFolderName
+        ]);
+
+        $response = $this->parseXMLObject($response);
+
+        if ($response->ErrCount > 0) {
+            throw new EnomApiException($response->errors);
+        }
+
+        return $response->tldlist;
+    }
+}

--- a/src/Service.php
+++ b/src/Service.php
@@ -1,0 +1,23 @@
+<?php
+namespace Coreproc\Enom;
+
+class Service
+{
+	 protected function doGetRequest($command, $additionalParams = [])
+    {
+        $params = [
+            'command' => $command,
+        ];
+
+        if (count($additionalParams)) {
+            $params = array_merge($params, $additionalParams);
+        }
+
+        return $this->client->get('', ['query' => $params])->xml();
+    }
+
+    protected function parseXMLObject($object)
+    {
+        return json_decode(json_encode($object));
+    }
+}

--- a/src/Tld.php
+++ b/src/Tld.php
@@ -2,7 +2,7 @@
 
 namespace Coreproc\Enom;
 
-class Tld
+class Tld extends Service
 {
 
     /**
@@ -55,23 +55,5 @@ class Tld
         $response = $this->parseXMLObject($response);
 
         return $response->tldlist;
-    }
-
-    private function doGetRequest($command, $additionalParams = [])
-    {
-        $params = [
-            'command' => $command,
-        ];
-
-        if (count($additionalParams)) {
-            $params = array_merge($params, $additionalParams);
-        }
-
-        return $this->client->get('', ['query' => $params])->xml();
-    }
-
-    private function parseXMLObject($object)
-    {
-        return json_decode(json_encode($object));
     }
 }


### PR DESCRIPTION
I needed some magic folder functions so added a MagicFolder api class and also put the doGetRequest and parseXMLObject into a base class. I tested a very basic moving a single domain to a folder and it worked as expected. Didn't test anything else.
